### PR TITLE
Alter failed set

### DIFF
--- a/lib/rails_api_logger/request_log.rb
+++ b/lib/rails_api_logger/request_log.rb
@@ -6,7 +6,7 @@ class RequestLog < ActiveRecord::Base
 
   belongs_to :loggable, optional: true, polymorphic: true
 
-  scope :failed, -> { where.not(response_code: 200..299) }
+  scope :failed, -> { where(response_code: 400..599).or(where.not(ended_at: nil).where(response_code: nil)) }
 
   validates :method, presence: true
   validates :path, presence: true

--- a/spec/request_log_spec.rb
+++ b/spec/request_log_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+
+RSpec.describe RequestLog do
+  describe ".failed" do
+    [OutboundRequestLog, InboundRequestLog].each do |klass|
+      it "returns only failed requests for #{klass}" do
+        klass.create!(path: "/ok", method: "GET", response_code: 200)
+        klass.create!(path: "/redirecting", method: "GET", response_code: 308)
+        klass.create!(path: "/bad_request", method: "GET", response_code: 400)
+        klass.create!(path: "/server_error", method: "GET", response_code: 500)
+        klass.create!(path: "/long_and_still_running", method: "GET", response_code: nil, ended_at: nil)
+        klass.create!(path: "/timeout", method: "GET", response_code: nil, ended_at: 1.hour.ago)
+
+        expect(klass.failed).to contain_exactly(
+          having_attributes(path: "/bad_request"),
+          having_attributes(path: "/server_error"),
+          having_attributes(path: "/timeout")
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
`RequestLog.failed` will now include

* timeouts or network errors
* requests which are parts of a valid request chain (e.g. `101` or `301`).
