### PR TITLE
Allow user to skip logging based on host as well as path

### DIFF
--- a/lib/rails_api_logger/inbound_requests_logger_middleware.rb
+++ b/lib/rails_api_logger/inbound_requests_logger_middleware.rb
@@ -1,12 +1,14 @@
 class InboundRequestsLoggerMiddleware
-  attr_accessor :only_state_change, :path_regexp, :skip_request_body_regexp, :skip_response_body_regexp
+  attr_accessor :only_state_change, :host_regexp, :path_regexp, :skip_request_body_regexp, :skip_response_body_regexp
 
   def initialize(app, only_state_change: true,
+    host_regexp: /.*/,
     path_regexp: /.*/,
     skip_request_body_regexp: nil,
     skip_response_body_regexp: nil)
     @app = app
     self.only_state_change = only_state_change
+    self.host_regexp = host_regexp
     self.path_regexp = path_regexp
     self.skip_request_body_regexp = skip_request_body_regexp
     self.skip_response_body_regexp = skip_response_body_regexp
@@ -48,7 +50,9 @@ class InboundRequestsLoggerMiddleware
   end
 
   def log?(env, request)
-    env["PATH_INFO"] =~ path_regexp && (!only_state_change || request_with_state_change?(request))
+    # The HTTP_HOST header is preferred to the SERVER_NAME header per the Rack spec: https://github.com/rack/rack/blob/main/SPEC.rdoc#label-The+Environment
+    host = env["HTTP_HOST"] || env["SERVER_NAME"]
+    host =~ host_regexp && env["PATH_INFO"] =~ path_regexp && (!only_state_change || request_with_state_change?(request))
   end
 
   def parsed_body(body)

--- a/rails_api_logger.gemspec
+++ b/rails_api_logger.gemspec
@@ -29,11 +29,11 @@ Gem::Specification.new do |spec|
   spec.add_dependency "nokogiri"
   spec.add_dependency "zeitwerk", ">= 2.0.0"
 
-  spec.add_development_dependency "sqlite3", "~> 1.4.0"
+  spec.add_development_dependency "sqlite3", ">= 2.1"
   spec.add_development_dependency "pg", "~> 1.5.4"
   spec.add_development_dependency "standard", "~> 1.31"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-rails", "~> 7.1.0"
-  spec.add_development_dependency "rack"
+  spec.add_development_dependency "rack", "< 3"
 end


### PR DESCRIPTION
Pushing this up to get some opinions on it.

We have a Rails app serving an API layer on `api.*`, and a web app on `app.*`. We're using routing constraints to determine which routes are accessible on which subdomain. At the moment, we're running into a similar issue to that in #8 (same manifestation, different cause), in that junk requests to `app.*.com/api/v1/some-path` are resulting in a 500 error.

This PR allows the user to specify a host regex to determine whether a request should be logged, similar to the way the path regex functions currently. This allows us to skip these junk requests at the middleware layer to stop them from causing the stack overflows.