### PR TITLE
Fix `NameError: uninitialized constant RailsApiLogger::Loggable (NameError)`

### DIFF
--- a/lib/rails_api_logger.rb
+++ b/lib/rails_api_logger.rb
@@ -1,7 +1,8 @@
-require "rails_api_logger/version"
-require "rails_api_logger/engine"
+
 require_relative "../app/models/rails_api_logger/loggable"
 require_relative "../app/middlewares/rails_api_logger/middleware"
+require "rails_api_logger/version"
+require "rails_api_logger/engine"
 
 require "rails"
 require "nokogiri"


### PR DESCRIPTION
Hello, 

Let me start by thanking you for this gem, it's exactly what I needed. 

I've installed it in a rails 8.0 project but ran into some issues on the CI. 

```
NameError: uninitialized constant RailsApiLogger::Loggable (NameError)00:25
      include RailsApiLogger::Loggable00:25
                            ^^^^^^^^^^00:25
/home/semaphore/erp/vendor/bundle/ruby/3.3.0/gems/rails_api_logger-0.10.1/lib/rails_api_logger/engine.rb:22:in `block in <class:Engine>'00:25
/home/semaphore/erp/vendor/bundle/ruby/3.3.0/gems/activesupport-8.0.2/lib/active_support/lazy_load_hooks.rb:97:in `class_eval'00:25
/home/semaphore/erp/vendor/bundle/ruby/3.3.0/gems/activesupport-8.0.2/lib/active_support/lazy_load_hooks.rb:97:in `block in execute_hook'00:25
/home/semaphore/erp/vendor/bundle/ruby/3.3.0/gems/activesupport-8.0.2/lib/active_support/lazy_load_hooks.rb:87:in `with_execution_control'00:25
/home/semaphore/erp/vendor/bundle/ruby/3.3.0/gems/activesupport-8.0.2/lib/active_support/lazy_load_hooks.rb:92:in `execute_hook'00:25
/home/semaphore/erp/vendor/bundle/ruby/3.3.0/gems/activesupport-8.0.2/lib/active_support/lazy_load_hooks.rb:62:in `block in on_load'00:25
/home/semaphore/erp/vendor/bundle/ruby/3.3.0/gems/activesupport-8.0.2/lib/active_support/lazy_load_hooks.rb:61:in `each'00:25
/home/semaphore/erp/vendor/bundle/ruby/3.3.0/gems/activesupport-8.0.2/lib/active_support/lazy_load_hooks.rb:61:in `on_load'00:25
/home/semaphore/erp/vendor/bundle/ruby/3.3.0/gems/rails_api_logger-0.10.1/lib/rails_api_logger/engine.rb:21:in `<class:Engine>'00:25
/home/semaphore/erp/vendor/bundle/ruby/3.3.0/gems/rails_api_logger-0.10.1/lib/rails_api_logger/engine.rb:2:in `<module:RailsApiLogger>'00:25
/home/semaphore/erp/vendor/bundle/ruby/3.3.0/gems/rails_api_logger-0.10.1/lib/rails_api_logger/engine.rb:1:in `<main>'00:25
<internal:/home/semaphore/.rbenv/versions/3.3.5/lib/ruby/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require'00:25
<internal:/home/semaphore/.rbenv/versions/3.3.5/lib/ruby/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require'00:25
/home/semaphore/erp/vendor/bundle/ruby/3.3.0/gems/bootsnap-1.18.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'00:25
/home/semaphore/erp/vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.7.2/lib/zeitwerk/core_ext/kernel.rb:34:in `require'00:25
/home/semaphore/erp/vendor/bundle/ruby/3.3.0/gems/rails_api_logger-0.10.1/lib/rails_api_logger.rb:2:in `<main>'00:25
/home/semaphore/erp/vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.7.2/lib/zeitwerk/core_ext/kernel.rb:34:in `require'00:25
/home/semaphore/erp/vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.7.2/lib/zeitwerk/core_ext/kernel.rb:34:in `require'00:25
/home/semaphore/erp/vendor/bundle/ruby/3.3.0/gems/bundler-2.4.21/lib/bundler/runtime.rb:60:in `block (2 levels) in require'00:25
/home/semaphore/erp/vendor/bundle/ruby/3.3.0/gems/bundler-2.4.21/lib/bundler/runtime.rb:55:in `each'00:25
/home/semaphore/erp/vendor/bundle/ruby/3.3.0/gems/bundler-2.4.21/lib/bundler/runtime.rb:55:in `block in require'00:25
/home/semaphore/erp/vendor/bundle/ruby/3.3.0/gems/bundler-2.4.21/lib/bundler/runtime.rb:44:in `each'00:25
/home/semaphore/erp/vendor/bundle/ruby/3.3.0/gems/bundler-2.4.21/lib/bundler/runtime.rb:44:in `require'00:25
/home/semaphore/erp/vendor/bundle/ruby/3.3.0/gems/bundler-2.4.21/lib/bundler.rb:187:in `require'00:25
/home/semaphore/erp/config/application.rb:9:in `<main>'
```

This PR fixes the issue. 