### PR TITLE
Add loggable model requirement to RailsApiLogger engine

### DIFF
--- a/lib/rails_api_logger/engine.rb
+++ b/lib/rails_api_logger/engine.rb
@@ -1,3 +1,5 @@
+require_relative '../../app/models/rails_api_logger/loggable'
+
 module RailsApiLogger
   class Engine < ::Rails::Engine
     isolate_namespace RailsApiLogger


### PR DESCRIPTION
After upgrading to v0.10 I got the following error:
`uninitialized constant RailsApiLogger::Loggable (NameError)`

It means that the RailsApiLogger::Loggable module is being referenced before it’s loaded.

Zeitwerk manages the Rails autoloading mechanism, which doesn’t automatically load files from the app/models directory unless they’re explicitly referenced or used within the application.

This patch resolves this issue.
